### PR TITLE
Add Download dependencies with go mod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 # Builder
-
 FROM golang:1.12.6-alpine3.9 as builder
 
-WORKDIR /go/src/github.com/openbank/openbank
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /src
+
+# Copy go.mod and go.sum and run 'go mod download'.
+# This way, docker will keep this costly download step cached as long as the
+# go.mod and go.sum files don't change.
+COPY go.* ./
+RUN go mod download
 
 COPY . .
 
 ARG VERSION
-RUN CGO_ENABLE=0 go build -ldflags="-w -s -X main.version=$VERSION" -o openbank
+RUN CGO_ENABLED=0 go build -ldflags="-w -s -X main.version=$VERSION" -o openbank
 
 # Run the application
 FROM alpine:3.9
@@ -15,7 +22,7 @@ FROM alpine:3.9
 RUN apk --no-cache add ca-certificates tzdata
 
 WORKDIR /root/
-COPY --from=builder /go/src/github.com/openbank/openbank/openbank .
+COPY --from=builder /src/openbank .
 ADD env/sample.config env/config
 
 CMD ["./openbank"]


### PR DESCRIPTION
Add capability to download all dependencies using go mod download.
This solved issue if vendor folder not included in repository.