### PR TITLE
atm, card, statements, transactions, types: cleanup

### DIFF
--- a/v1/atm/atm.gunk
+++ b/v1/atm/atm.gunk
@@ -167,7 +167,7 @@ type ATMService interface {
 	//         Path:   "/v1/atms",
 	// }
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"ATMs"},
+	//         Tags:        []string{"ATM"},
 	//         Description: "Retrieves information regarding all the available ATMs.",
 	//         Summary:     "Retrieve all available ATMs",
 	//         Responses: map[string]openapiv2.Response{

--- a/v1/card/card.gunk
+++ b/v1/card/card.gunk
@@ -5,7 +5,6 @@
 //                 Description: "Provides create and read operations on the card resource.",
 //                 Version:     "1.0.0",
 //         },
-//         BasePath: "/v1",
 //         Schemes: []openapiv2.SwaggerScheme{
 //                 openapiv2.HTTPS,
 //         },
@@ -66,10 +65,10 @@ type Card struct {
 	// ID is a unique identifier of a card.
 	ID string `pb:"1" json:"id"`
 
-	// Account is the account id who owns the card.
+	// Account is the ID of the account associated with the card.
 	Account string `pb:"2" json:"account"`
 
-	// OwnerName is the owner name of the card.
+	// OwnerName is the name of the card owner.
 	OwnerName string `pb:"3" json:"owner_name"`
 
 	// ContactNumber is the contact number of the card owner.
@@ -84,40 +83,40 @@ type Card struct {
 	// Expiry is an expiry date of the card.
 	Expiry time.Time `pb:"7" json:"expiry"`
 
-	// Status is the status of the card, such as lock, unlock, active.
+	// Status is the status of the card.
 	Status types.CardStatus `pb:"8" json:"status"`
 
-	// AccessStatus is the access status of the card, such as often and rare.
+	// AccessStatus is the access status of the card.
 	AccessStatus types.CardAccessStatus `pb:"9" json:"access_status"`
 }
 
-// GetCardRequest is a request to get card information.
+// GetCardRequest is the request envelope to retrieve card information.
 type GetCardRequest struct {
 	// CardToken is the identifier to get the card information.
 	CardToken string `pb:"1" json:"card_token"`
 }
 
-// UpdateCardStatusRequest is a request to update card status.
+// UpdateCardStatusRequest is the request envelope to update card status.
 type UpdateCardStatusRequest struct {
 	// CardToken is the identifier to get the card information.
 	CardToken string `pb:"1" json:"card_token"`
 
-	// Status is the status to be updated.
+	// Status is the new card status.
 	Status types.CardStatus `pb:"2" json:"status"`
 }
 
-// UpdateCardAccessStatusRequest is a request to update card access status.
+// UpdateCardAccessStatusRequest is the request envelope to update card access status.
 type UpdateCardAccessStatusRequest struct {
 	// CardToken is the identifier to get the card information.
 	CardToken string `pb:"1" json:"card_token"`
 
-	// AccessStatus is the card access status to be updated.
+	// AccessStatus is the new card access status.
 	AccessStatus types.CardAccessStatus `pb:"2" json:"access_status"`
 }
 
-// Result is result for update operation.
+// Result is result of the update operation.
 type Result struct {
-	// Success is the flag for success operation.
+	// Success is a boolean indicating the success of the operation.
 	Success bool `pb:"1" json:"success"`
 
 	// ErrorCode is the code of the error.
@@ -138,10 +137,15 @@ type CardService interface {
 	// +gunk openapiv2.Operation{
 	//         Tags:        []string{"Card"},
 	//         Description: "Retrieves all data from a card, selected by the card_token you supplied.",
-	//         Summary:     "Retrieve a card information",
+	//         Summary:     "Retrieve card information",
 	//         Responses: map[string]openapiv2.Response{
 	//                 "200": openapiv2.Response{
 	//                         Description: "Request executed successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/cardCard",
+	//                                 },
+	//                         },
 	//                 },
 	//                 "404": openapiv2.Response{
 	//                         Description: "Returned when the resource is not found.",
@@ -168,9 +172,9 @@ type CardService interface {
 	//         Path:   "/v1/card/status",
 	// }
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"Card", "CardStatus"},
+	//         Tags:        []string{"Card"},
 	//         Description: "Update Card status.",
-	//         Summary:     "Update Card Status.",
+	//         Summary:     "Update card status",
 	//         Responses: map[string]openapiv2.Response{
 	//                 "200": openapiv2.Response{
 	//                         Description: "Request executed successfully.",
@@ -200,12 +204,17 @@ type CardService interface {
 	//         Path:   "/v1/card/access_status",
 	// }
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"Card", "AccessStatus"},
+	//         Tags:        []string{"Card"},
 	//         Description: "Update card access status.",
-	//         Summary:     "Update card access status.",
+	//         Summary:     "Update card access status",
 	//         Responses: map[string]openapiv2.Response{
 	//                 "200": openapiv2.Response{
 	//                         Description: "Request executed successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/cardResult",
+	//                                 },
+	//                         },
 	//                 },
 	//                 "404": openapiv2.Response{
 	//                         Description: "Returned when the resource is not found.",

--- a/v1/statements/statements.gunk
+++ b/v1/statements/statements.gunk
@@ -178,6 +178,5 @@ type StatementService interface {
 	//                 },
 	//         },
 	// }
-
 	GetStatements(GetStatementsRequest) GetStatementsResponse
 }

--- a/v1/transactions/transactions.gunk
+++ b/v1/transactions/transactions.gunk
@@ -5,7 +5,6 @@
 //                 Description: "Provides create and read operations on the transaction resource.",
 //                 Version:     "1.0.0",
 //         },
-//         BasePath: "/v1",
 //         Schemes: []openapiv2.SwaggerScheme{
 //                 openapiv2.HTTPS,
 //         },
@@ -120,7 +119,7 @@ type Transaction struct {
 	Remarks string `pb:"10" json:"remarks"`
 }
 
-// BankAccountInfo holds a lightweight account information.
+// BankAccountInfo holds lightweight account information.
 type BankAccountInfo struct {
 	// AccountID is the identifier of the account.
 	AccountID string `pb:"1" json:"account_id"`
@@ -160,7 +159,7 @@ type GetTransactionsRequest struct {
 	NextStartingIndex string `pb:"5" json:"next_starting_index"`
 }
 
-// GetTransactionsResponse wraps the list of transactions.
+// GetTransactionsResponse is the response envelope for retrieving a list of transactions.
 type GetTransactionsResponse struct {
 	// Result is a list containing up to 20 transactions.
 	Result []Transaction `pb:"1" json:"result"`
@@ -172,7 +171,7 @@ type GetTransactionsResponse struct {
 	LastRunningBalance types.Amount `pb:"3" json:"last_running_balance"`
 }
 
-// CreateTransactionRequest wraps all required field for a transaction creation.
+// CreateTransactionRequest is the request envelope for creating a transaction.
 type CreateTransactionRequest struct {
 	// SourceAccountID is the identifier of the account emitting the transaction.
 	SourceAccountID string `pb:"1" json:"source_account_id"`
@@ -199,7 +198,7 @@ type CreateTransactionResponse struct {
 // TFAType is available type of TFA.
 type TFAType int
 
-const(
+const (
 	_ TFAType = iota
 
 	// SMS Message.
@@ -209,9 +208,8 @@ const(
 	SAFEKEY
 )
 
-// ApprovePaymentRequest wraps all request to request approval
-// of pending transaction.
-type ApprovePaymentRequest struct{
+// ApprovePaymentRequest is the request envelope to approve a pending transaction.
+type ApprovePaymentRequest struct {
 	// TransactionID is the transaction unique identifier.
 	TransactionID string `pb:"1" json:"transaction_id"`
 
@@ -222,8 +220,8 @@ type ApprovePaymentRequest struct{
 	TFAType TFAType `pb:"3" json:"tfa_type"`
 }
 
-// ApprovePaymentResponse response for approve payment request.
-type ApprovePaymentResponse struct{
+// ApprovePaymentResponse is the response envelope for approving a pending transaction.
+type ApprovePaymentResponse struct {
 	// AuthorizationID is the executable code is obtained from
 	// the payment feedback result
 	AuthorizationID string `pb:"1" json:"authorization_id"`
@@ -232,8 +230,8 @@ type ApprovePaymentResponse struct{
 	SMSCode int64 `pb:"2" json:"sms_code"`
 }
 
-// TFARequest is request to get two factor authentication.
-type TFARequest struct{
+// TFARequest is request envelope for conducting 2FA.
+type TFARequest struct {
 	// TransactionID is transaction / payment identification code requires approval.
 	TransactionID string `pb:"1" json:"transaction_id"`
 
@@ -247,8 +245,8 @@ type TFARequest struct{
 	TFAType TFAType `pb:"4" json:"tfa_type"`
 }
 
-// TFAResponse is the response for TFARequest
-type TFAResponse struct{
+// TFAResponse is the response envelope for a 2FA request.
+type TFAResponse struct {
 	// TraceNumber is the transaction reference code.
 	TraceNumber string `pb:"1" json:"trace_number"`
 }
@@ -330,6 +328,11 @@ type TransactionService interface {
 	//         Responses: map[string]openapiv2.Response{
 	//                 "201": openapiv2.Response{
 	//                         Description: "Transaction created successfully.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/transactionsCreateTransactionResponse",
+	//                                 },
+	//                         },
 	//                 },
 	//         },
 	//         Security: []openapiv2.SecurityRequirement{
@@ -354,12 +357,17 @@ type TransactionService interface {
 	//         Body:   "*",
 	// }
 	// +gunk openapiv2.Operation{
-	//         Tags:        []string{"AppproveTransaction","Transaction"},
-	//         Description: "Approves a pending transaction.",
-	//         Summary:     "Approves a pending transaction.",
+	//         Tags:        []string{"Transaction"},
+	//         Description: "Approve a pending transaction.",
+	//         Summary:     "Approve a pending transaction",
 	//         Responses: map[string]openapiv2.Response{
 	//                 "200": openapiv2.Response{
 	//                         Description: "Transaction successfully approved.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/transactionsApprovePaymentResponse",
+	//                                 },
+	//                         },
 	//                 },
 	//         },
 	//         Security: []openapiv2.SecurityRequirement{
@@ -376,7 +384,7 @@ type TransactionService interface {
 	// }
 	ApprovePayment(ApprovePaymentRequest) ApprovePaymentResponse
 
-	// TFA does 2fa verification for a approved transaction.
+	// TFA does 2FA verification for an approved transaction.
 	//
 	// +gunk http.Match{
 	//         Method: "POST",
@@ -385,11 +393,16 @@ type TransactionService interface {
 	// }
 	// +gunk openapiv2.Operation{
 	//         Tags:        []string{"Transaction"},
-	//         Description: "Authorization allows execution of transactions with 2-layer authentication (two factor authentication).",
-	//         Summary:     "Authorize the transaction",
+	//         Description: "Authorization allows execution of transactions with 2-factor authentication (2FA).",
+	//         Summary:     "Authorize a transaction with 2FA",
 	//         Responses: map[string]openapiv2.Response{
 	//                 "200": openapiv2.Response{
 	//                         Description: "Transaction authorized.",
+	//                         Schema: openapiv2.Schema{
+	//                                 JSONSchema: openapiv2.JSONSchema{
+	//                                         Ref: "#/definitions/transactionsTFAResponse",
+	//                                 },
+	//                         },
 	//                 },
 	//         },
 	//         Security: []openapiv2.SecurityRequirement{
@@ -405,5 +418,4 @@ type TransactionService interface {
 	//         },
 	// }
 	TFA(TFARequest) TFAResponse
-
 }

--- a/v1/types/types.gunk
+++ b/v1/types/types.gunk
@@ -51,7 +51,7 @@ const (
 	Bri
 	DummyBank
 	Bdo
-	//Bpi
+	Bpi
 	Aceh
 	Agris
 	Agroniaga


### PR DESCRIPTION
atm:
 - fix incorrect tag

types:
 - fix mistakenly commented bank

statements:
 - remove unwanted newline that prevented the annotation from being used

all:
  - Fix typos and grammatical errors, try to make the writing style
    more consistent

  - Remove BasePath from swagger definitions to prevent it being doubled
    (e.g. /v1/v1/accounts/check)

  - Fix missing/incorrect response schemas

  - Make godoc comments more consistent

  - Fix endpoint tags to ensure correct grouping